### PR TITLE
Updated _ppgplot.c to be consistent with Numpy v2.0 C-API

### DIFF
--- a/src/_ppgplot.c
+++ b/src/_ppgplot.c
@@ -83,23 +83,6 @@ tofloatvector (PyObject *o, float **v, npy_intp *vsz)
 
 /*************************************************************************/
 
-//static PyObject *
-//tofloatmatX(PyObject *o, float **m, npy_intp *nr, npy_intp *nc)
-//{
-//    /* 
-//       This is based on the tofloatvector() changes by TRM.
-//    */
-//    PyArrayObject* array = NULL;
-//    array = (PyArrayObject*) PyArray_FromAny(o, PyArray_DescrFromType(NPY_FLOAT), 1, 1,
-//      NPY_ARRAY_ALIGNED | NPY_ARRAY_C_CONTIGUOUS | NPY_ARRAY_FORCECAST, NULL);
-//    if(array == NULL) return NULL;
-//    *vsz = PyArray_Size(array);
-//    *v   = (float*) PyArray_DATA(array);
-//    return (PyObject*)array;
-//}
-
-/*************************************************************************/
-
 static PyObject *
 tofloatmat(PyObject *o, float **m, int *nr, int *nc)
 {


### PR DESCRIPTION
Hi Tom,

I just updated _ppgplot.c so that it doesn't use any of the old deprecated Numpy C-API, and it is now compatible with v2.0, as well. I have included this in my PRESTO package as well. I've only done a relatively minor amount of testing, but it seems to work well, so far.

Thanks for your earlier tweaks!

Scott